### PR TITLE
Fix sleep obfuscation timing and builder bypass

### DIFF
--- a/payloads/Demon/src/core/Obf.c
+++ b/payloads/Demon/src/core/Obf.c
@@ -692,7 +692,8 @@ UINT32 SleepTime(
                 // seconds until start of working hours from current time
                 SleepTime += ( StartHour - SystemTime.wHour ) * 60 + ( StartMinute - SystemTime.wMinute );
             }
-            SleepTime *= 1000;
+            // SleepTime is calculated in minutes; convert to milliseconds
+            SleepTime *= 60 * 1000;
         }
     }
     // MaxVariation will be non-zero if sleep jitter was specified

--- a/teamserver/pkg/common/builder/builder.go
+++ b/teamserver/pkg/common/builder/builder.go
@@ -734,7 +734,7 @@ func (b *Builder) PatchConfig() ([]byte, error) {
 		if ConfigObfTechnique != SLEEPOBF_NO_OBF {
 			switch val {
 			case "jmp rax":
-				ConfigObfTechnique = SLEEPOBF_BYPASS_JMPRAX
+				ConfigObfBypass = SLEEPOBF_BYPASS_JMPRAX
 				if !b.silent {
 					b.SendConsoleMessage("Info", "sleep jump gadget \"jmp rax\" has been specified")
 				}


### PR DESCRIPTION
## Summary
- Correct working-hours sleep calculation by converting minutes to milliseconds
- Fix sleep jump gadget configuration to set bypass rather than technique

## Testing
- `gofmt -w teamserver/pkg/common/builder/builder.go`
- `go build ./...` *(fails: command was interrupted due to long execution)*
- `gcc -fsyntax-only -Ipayloads/Demon/include -Ipayloads/Demon/include/common -Ipayloads/Demon/include/core payloads/Demon/src/core/Obf.c` *(fails: fatal error: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a588ff746083228c1643e78463414a